### PR TITLE
Fix bug introduced by 1272129

### DIFF
--- a/client.go
+++ b/client.go
@@ -218,12 +218,14 @@ func (c *Client) do(req *http.Request) (response *Response, err error) {
 		return nil, fmt.Errorf("No body! Check URL: %s", req.URL)
 	}
 
-	response.Raw = body
-	
-	if err = json.Unmarshal(body, &response); err != nil {
-		return response, err
+	err = json.Unmarshal(body, response)
+	if err != nil || response == nil {
+		response = &Response{
+			Raw: body,
+		}
 	}
-	return response, nil
+	
+	return response, err
 }
 
 func (c *Client) doWithRetry(req *http.Request) (response *Response, err error) {

--- a/client.go
+++ b/client.go
@@ -274,7 +274,10 @@ func (c *Client) checkToken(response *Response) (retry bool, err error) {
 		}
 		_, err = c.RefreshToken()
 	}
-	return retry, errors.New("Invalid/Expired Marketo Auth Token")
+	if err != nil {
+		return retry, errors.New("Invalid/Expired Marketo Auth Token")
+	}
+	return retry, nil
 }
 
 // Get performs an HTTP GET for the specified resource url

--- a/client.go
+++ b/client.go
@@ -36,6 +36,7 @@ type Response struct {
 	Errors        []Reason        `json:"errors,omitempty"`
 	Result        json.RawMessage `json:"result,omitempty"`
 	Warnings      []Reason        `json:"warning,omitempty"`
+	Raw          []byte
 }
 
 // AuthToken holds data from Auth request
@@ -217,8 +218,10 @@ func (c *Client) do(req *http.Request) (response *Response, err error) {
 		return nil, fmt.Errorf("No body! Check URL: %s", req.URL)
 	}
 
+	response.Raw = body
+	
 	if err = json.Unmarshal(body, &response); err != nil {
-		return nil, err
+		return response, err
 	}
 	return response, nil
 }


### PR DESCRIPTION
Fix bug introduced by 1272129

After changes, checkToken() will have returned an error even when there was none.  

In this change we take advantage of named return type variable declared in method signature.